### PR TITLE
Add CI workflow to validate PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Why:

Currently, PRs can be merged without verifying that the project builds successfully. This could introduce breaking changes to main.

## Changes:

* Added `ci.yml` that runs on PRs to main
* Validates the build using pnpm install + pnpm build
* Closes #13