### PR TITLE
Improve accessibility for sponsor button

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,7 +33,7 @@ import { SPONSORS_EMAIL } from './constants'
           id="sponsor-btn"
           type="button"
           data-email={SPONSORS_EMAIL}
-          aria-label="Copiar email de contacto para patrocinadores"
+          aria-describedby="sponsor-hint"
           class="group relative px-7 py-2 bg-green-500 text-black font-mono font-bold text-lg hover:bg-green-400 transition-all duration-300 shadow-[0_0_15px_rgba(34,197,94,0.5)] hover:shadow-[0_0_25px_rgba(34,197,94,0.8)] cursor-pointer focus:outline-none focus:ring-4 focus:ring-green-300/50 rounded-sm"
         >
           <span
@@ -41,9 +41,19 @@ import { SPONSORS_EMAIL } from './constants'
           ></span>
 
           <span id="sponsor-text">
-            <span aria-hidden="true">&lt; </span>BECOME A SPONSOR<span aria-hidden="true"> /&gt;</span>
+            <span aria-hidden="true">&lt; </span lang='en'>BECOME A SPONSOR<span aria-hidden="true"> /&gt;</span>
           </span>
+          <span id="sponsor-hint" class="sr-only">Copia el email de contacto para patrocinadores</span>
         </button>
+
+        <div
+          id="copy-confirmation"
+          role="status"
+          tabindex="-1"
+          class="hidden px-7 py-2 text-green-400 font-mono font-bold text-lg focus:outline-none focus:ring-4 focus:ring-green-300/50 rounded-sm"
+        >
+          <span aria-hidden="true">[ </span lang='en'>EMAIL COPIED!<span aria-hidden="true"> ]</span>
+        </div>
       </div>
     </div>
 
@@ -113,23 +123,24 @@ import { SPONSORS_EMAIL } from './constants'
 
     // COPY MAIL LOGIC
     const sponsorBtn = document.getElementById('sponsor-btn')
-    const sponsorText = document.getElementById('sponsor-text')
+    const copyConfirmation = document.getElementById('copy-confirmation')
     const email = sponsorBtn?.dataset.email as string
 
-    if (sponsorBtn && sponsorText && email) {
+    if (sponsorBtn && copyConfirmation && email) {
       sponsorBtn.onclick = async () => {
         try {
           await navigator.clipboard.writeText(email)
 
-          const originalHTML = sponsorText.innerHTML
-          sponsorText.innerHTML =
-            '<span aria-hidden="true">[ </span>EMAIL COPIED!<span aria-hidden="true"> ]</span>'
-
-          sponsorBtn.setAttribute('aria-label', 'Email copiado exitosamente')
+          // Hide button, show confirmation
+          sponsorBtn.classList.add('hidden')
+          copyConfirmation.classList.remove('hidden')
+          copyConfirmation.focus()
 
           setTimeout(() => {
-            sponsorText.innerHTML = originalHTML
-            sponsorBtn.setAttribute('aria-label', 'Copiar email de contacto para patrocinadores')
+            // Hide confirmation, show button and restore focus
+            copyConfirmation.classList.add('hidden')
+            sponsorBtn.classList.remove('hidden')
+            sponsorBtn.focus()
           }, 2000)
         } catch (err) {
           console.error('Failed to copy', err)


### PR DESCRIPTION
# Improve accessibility for sponsor button

## Summary

This PR improves the accessibility of the "Become a Sponsor" button that copies the sponsor contact email to the clipboard.

## Changes

### 1. Visual feedback with focus management

- When the button is clicked, it is replaced by a confirmation message ("EMAIL COPIED!")
- The confirmation element (not a button) receives focus, ensuring screen readers announce the success message
- After 2 seconds, the button reappears and focus is restored to it
- This works consistently across all interaction methods: mouse click, keyboard (Space/Enter), and screen reader actions (VoiceOver VO+Space)

### 2. Equivalent experience for all users (WCAG 2.5.3 - Label in Name)

**Before:** The button used `aria-label="Copiar email de contacto para patrocinadores"` which completely replaced the visible text "BECOME A SPONSOR". This created different experiences:
- Visual users saw: "BECOME A SPONSOR"
- Screen reader users heard: "Copiar email de contacto para patrocinadores"

**After:** Changed to use `aria-describedby` instead, so screen readers now announce:
> "BECOME A SPONSOR, button. Copies the sponsor contact email"

This provides an equivalent experience while still giving screen reader users the additional context about what the button does.

#### WCAG Reference

From [WCAG 2.5.3 - Label in Name (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html):

> "For user interface components with labels that include text or images of text, the name contains the text that is presented visually."

> "The intent of this success criterion is to ensure that the words which visually label a component are also the words associated with the component programmatically. This helps ensure that people with disabilities can rely on visible labels as a means to interact with the components."

> "When these match, speech-input users (i.e., users of speech recognition applications) can navigate by speaking the visible text labels of components, such as menus, links, and buttons, that appear on the screen."

> "Both `aria-label` and `aria-labelledby` take precedence in the name calculation, overriding the visible text as the accessible name even when the visible text label is programmatically associated with the control. For this reason, when a visible label already exists, `aria-label` should be avoided or used carefully."

### 3. Confirmation message accessibility

- Added `role="status"` to the confirmation div for proper semantics
- Added `tabindex="-1"` to allow programmatic focus
- The message is announced by screen readers when it appears

## Testing

- [x] Mouse click shows confirmation and copies email
- [x] Keyboard activation (Space/Enter) works correctly
- [x] VoiceOver announces button name and description
- [x] VoiceOver announces confirmation message on activation
- [x] Focus management works correctly (moves to confirmation, returns to button)
