### PR TITLE
The display message should not look like a button

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -50,9 +50,9 @@ import { SPONSORS_EMAIL } from './constants'
           id="copy-confirmation"
           role="status"
           tabindex="-1"
-          class="hidden px-7 py-2 text-green-400 font-mono font-bold text-lg focus:outline-none focus:ring-4 focus:ring-green-300/50 rounded-sm"
+          class="hidden px-7 py-2 text-green-400 font-mono font-bold text-lg rounded-sm"
         >
-          <span aria-hidden="true">[ </span lang='en'>EMAIL COPIED!<span aria-hidden="true"> ]</span>
+          <span aria-hidden="true"> &lt;!-- </span lang='en'>EMAIL COPIED!<span aria-hidden="true"> --&gt;</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Change the ‘Emil copied’ message styling to prevent it from looking like a button.

The focus styling made it look like a button, so this PR removes the custom focus style. In the terminal, `[ XXX ]` also resembled a button, so `[` was replaced with other decorative characters.

>[!NOTE]
>PR is opened against the `fix_accessibility` branch rather than `main`.