### PR TITLE
fix(sponsors): Traducción del título de la página de patrocinios.

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 onlyBuiltDependencies:
   - esbuild
   - sharp
+
+packages:
+  - src

--- a/src/i18n/sponsors/ca.ts
+++ b/src/i18n/sponsors/ca.ts
@@ -1,8 +1,9 @@
 export const ca = {
+  title: 'Oportunitats de patrocini - PyConES 2026',
   hero: {
     date: 'BARCELONA, 6-8 NOVEMBRE',
     title: 'PyConES 2026',
-    subtitle: 'Oportunitats de Patrocini',
+    subtitle: 'Oportunitats de patrocini',
   },
   about: {
     title: 'Sobre la PyConES',

--- a/src/i18n/sponsors/en.ts
+++ b/src/i18n/sponsors/en.ts
@@ -1,4 +1,5 @@
 export const en = {
+  title: 'Sponsorship Opportunities - PyConES 2026',
   hero: {
     date: 'BARCELONA, NOVEMBER 6-8',
     title: 'PyConES 2026',

--- a/src/i18n/sponsors/es.ts
+++ b/src/i18n/sponsors/es.ts
@@ -1,8 +1,9 @@
 export const es = {
+  title: 'Oportunidades de patrocinio - PyConES 2026',
   hero: {
     date: 'BARCELONA, 6-8 NOVIEMBRE',
     title: 'PyConES 2026',
-    subtitle: 'Oportunidades de Patrocinio',
+    subtitle: 'Oportunidades de patrocinio',
   },
   about: {
     title: 'Sobre la PyConES',

--- a/src/pages/[lang]/sponsors.astro
+++ b/src/pages/[lang]/sponsors.astro
@@ -13,6 +13,7 @@ const t = texts[(lang || 'es') as keyof typeof texts]
 console.error('DEBUG -> Contenido de textsHERO:', t.hero)
 
 const {
+  title,
   hero,
   about,
   stats,
@@ -36,7 +37,7 @@ const {
 } = t
 ---
 
-<Layout title="Oportunidades de Patrocinio - PyConES 2026">
+<Layout title={title}>
   <div
     class="page-wrapper text-[#e5e5e5] font-sans min-h-screen w-full absolute top-0 left-0 z-10 overflow-x-hidden"
   >


### PR DESCRIPTION
Pequeño cambio en pnpm-workspace.yaml para evitar error de falta de definición del campo "packages" al hacer `pnpm i`.