### PR TITLE
Feat: Eliminar emojis

### DIFF
--- a/src/pages/[lang]/sponsors.astro
+++ b/src/pages/[lang]/sponsors.astro
@@ -66,7 +66,7 @@ const {
           {
             stats.items.map((stat) => (
               <div class="bg-white text-pycon-black p-4 rounded-lg border border-white/10 text-center">
-                <div class="text-3xl mb-2" role="img" aria-hidden="true">
+                <div class="text-3xl mb-2" aria-hidden="true">
                   {stat.icon}
                 </div>
                 <div class="text-2xl font-bold ">{stat.value}</div>
@@ -99,7 +99,7 @@ const {
         <div class="grid md:grid-cols-2 gap-6">
           <div class="bg-white text-pycon-black p-6 rounded-lg border border-white/10">
             <h3 class="text-xl font-bold mb-4">
-              <span aria-hidden="true" role="img">📍</span>
+              <span aria-hidden="true">📍</span>
               {location.where}
             </h3>
             <p class="mb-4">
@@ -113,7 +113,7 @@ const {
           </div>
 
           <div class="bg-white text-pycon-black p-6 rounded-lg border border-white/10">
-            <h3 class="text-xl font-bold mb-4"><span aria-hidden="true" role="img">📅</span> {when.title}</h3>
+            <h3 class="text-xl font-bold mb-4"><span aria-hidden="true">📅</span> {when.title}</h3>
             <div class="space-y-3">
               <p>
                 <strong>{when.friday}: </strong>{when.fridayStrong}
@@ -151,7 +151,7 @@ const {
               {
                 whySponsor.items.map((item) => (
                   <div class="flex gap-3">
-                    <span class="text-xl" role="img" aria-hidden="true">
+                    <span class="text-xl" aria-hidden="true">
                       {item.icon}
                     </span>
                     <div>
@@ -173,12 +173,7 @@ const {
         <div class="bg-white text-pycon-black p-8 rounded-lg border border-white/10 mb-6">
           <h3 class="mb-6 font-mono">{audience.seniority}</h3>
 
-          <div
-            role="img"
-            aria-label=""
-            aria-hidden="true"
-            class="flex w-full h-12 rounded-lg overflow-hidden mb-3"
-          >
+          <div aria-label="" aria-hidden="true" class="flex w-full h-12 rounded-lg overflow-hidden mb-3">
             <div
               style="width: 38%"
               class="h-full min-w-[2rem] bg-pycon-yellow text-pycon-black text-xs font-bold flex items-center justify-center"
@@ -222,7 +217,7 @@ const {
           {
             audience.items.map((item) => (
               <div class="bg-white p-4 rounded-lg border border-white/10 text-center">
-                <div class="text-2xl mb-1" role="img" aria-hidden="true">
+                <div class="text-2xl mb-1" aria-hidden="true">
                   {item.icon}
                 </div>
                 <div class="text-lg font-bold text-pycon-black">{item.value}</div>
@@ -255,7 +250,6 @@ const {
                         <div
                           class="w-3 h-3 rounded-sm shrink-0"
                           style={`background-color: ${colors[i]};`}
-                          role="img"
                           aria-hidden="true"
                         />
                         <span aria-hidden="true" class="truncate">
@@ -488,7 +482,7 @@ const {
             {
               pythonSpainPoints.items.map((point) => (
                 <div class="flex gap-3">
-                  <span class="text-2xl" role="img" aria-hidden="true">
+                  <span class="text-2xl" aria-hidden="true">
                     {point.icon}
                   </span>
                   <div>


### PR DESCRIPTION
Los emojis son elementos accesibles porquè el lector de pantalla los sabe leer.

Cuando aportan información, se deben conservar, por ejemplo, una reacción a un comentario, una carita sonriente al final de una frase para expresar emoción, etc.

En mi opinión, la mayoría de emojis de la página de sponsors son puramente decorativos, para que la página se vea más bonita, por eso en esta PR los he marcado como `aria-hidden="true"`

También he añadido el `%` a los textos del apartado 'intereses' como pidió @dukebody 