### PR TITLE
chore(sponsors): Añadir Perk como main sponsor.

### DIFF
--- a/src/data/sponsors/perk.md
+++ b/src/data/sponsors/perk.md
@@ -1,0 +1,7 @@
+---
+name: 'Perk'
+website: 'https://www.travelperk.com/'
+tier: 'main'
+logobg: '#ffffff'
+logo: '/sponsors/perk.svg'
+---


### PR DESCRIPTION
Probablemente queremos añadir padding en las cajas y hacer la de Perk bastante más grande y centrada.

Ahora mismo no pinta bien:
<img width="479" height="307" alt="image" src="https://github.com/user-attachments/assets/b5cf06aa-40f4-4144-805c-8a4f071a6956" />

En la web de sponsors se ve mejor:
https://2026.es.pycon.org/en/sponsors/
<img width="532" height="474" alt="image" src="https://github.com/user-attachments/assets/0cea4748-9c17-42ee-b1b5-3bc0d9773853" />


¿Podemos repetir esto?