### PR TITLE
feat(sponsors): redesign sponsors section with elegant glassmorphism style

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,43 +1,34 @@
 ---
 interface Props {
-  variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
-  size?: 'sm' | 'md' | 'lg';
-  href?: string;
-  class?: string;
-  [x: string]: any;
+  variant?: 'primary' | 'secondary' | 'outline' | 'ghost'
+  size?: 'sm' | 'md' | 'lg'
+  href?: string
+  class?: string
+  [x: string]: any
 }
 
-const { 
-  variant = 'primary', 
-  size = 'md', 
-  href,
-  class: className,
-  ...rest 
-} = Astro.props;
+const { variant = 'primary', size = 'md', href, class: className, ...rest } = Astro.props
 
 const variants = {
   primary: 'bg-orange-500 text-white hover:bg-orange-600',
   secondary: 'bg-amber-400 text-stone-900 hover:bg-amber-500',
   outline: 'outline outline-2 outline-offset-[-2px] outline-orange-500 text-orange-500 hover:bg-orange-50',
-  ghost: 'text-stone-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800'
-};
+  ghost: 'text-stone-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800',
+}
 
 // Map sizes based on exact Figma sizes
 const sizes = {
   sm: 'h-8 px-3 py-1.5 text-sm leading-5',
   md: 'h-10 px-4 py-2 text-base leading-6', // Uses h-10 based on size specs, though some variants export h-11
-  lg: 'h-12 px-6 py-3 text-lg leading-7'
-};
+  lg: 'h-12 px-6 py-3 text-lg leading-7',
+}
 
-const baseClasses = 'inline-flex items-center justify-center font-[\'Outfit\'] font-medium rounded-lg text-center transition-colors duration-200 cursor-pointer';
+const baseClasses =
+  "inline-flex items-center justify-center font-['Outfit'] font-medium rounded-lg text-center transition-colors duration-200 cursor-pointer"
 
-const Element = href ? 'a' : 'button';
+const Element = href ? 'a' : 'button'
 ---
 
-<Element 
-  href={href} 
-  class:list={[baseClasses, variants[variant], sizes[size], className]}
-  {...rest}
->
+<Element href={href} class:list={[baseClasses, variants[variant], sizes[size], className]} {...rest}>
   <slot />
 </Element>

--- a/src/components/home/SectionSponsors.astro
+++ b/src/components/home/SectionSponsors.astro
@@ -27,50 +27,45 @@ const platinum = filterSponsorsByTier('platinum')
 const main = filterSponsorsByTier('main')
 ---
 
-<div class="flex flex-col items-center gap-4">
+<div class="flex flex-col items-center gap-6">
   <SectionTitle title={t['sponsors.title']} />
   <CenteredPanel text={t['sponsors.description']} />
 
-  <div class="w-full flex flex-col gap-8">
+  <div class="w-full flex flex-col gap-10 mt-4">
     <SponsorsGroup
       lang={lang}
       title={t['sponsors.main']}
       sponsors={main}
-      bgColor="bg-tier-main"
-      textColor="text-contrast-tier-main"
-      size={200}
+      tierColor="text-tier-main"
+      size={280}
     />
     <SponsorsGroup
       lang={lang}
       title={t['sponsors.platinum']}
       sponsors={platinum}
-      bgColor="bg-tier-platinum"
-      textColor="text-contrast-tier-platinum"
-      size={150}
+      tierColor="text-tier-platinum"
+      size={170}
     />
     <SponsorsGroup
       lang={lang}
       title={t['sponsors.gold']}
       sponsors={gold}
-      bgColor="bg-tier-gold"
-      textColor="text-contrast-tier-gold"
-      size={120}
+      tierColor="text-tier-gold"
+      size={140}
     />
     <SponsorsGroup
       lang={lang}
       title={t['sponsors.silver']}
       sponsors={silver}
-      bgColor="bg-tier-silver"
-      textColor="text-contrast-tier-silver"
-      size={100}
+      tierColor="text-tier-silver"
+      size={110}
     />
     <SponsorsGroup
       lang={lang}
       title={t['sponsors.bronze']}
       sponsors={bronze}
-      bgColor="bg-tier-bronze"
-      textColor="text-contrast-tier-bronze"
-      size={80}
+      tierColor="text-tier-bronze"
+      size={90}
     />
   </div>
 </div>

--- a/src/components/home/sponsors/SponsorsGroup.astro
+++ b/src/components/home/sponsors/SponsorsGroup.astro
@@ -6,43 +6,46 @@ interface Props {
   lang: string
   title: string
   sponsors: ISponsor[]
-  bgColor: string
-  textColor: string
+  tierColor: string
   size: number
 }
 
-const { title, sponsors, lang, bgColor, textColor, size } = Astro.props
+const { title, sponsors, lang, tierColor, size } = Astro.props
 const t = texts[lang as keyof typeof texts]
 ---
 
-<div class="w-full">
-  <h4 class={`p-2 text-black rounded ${bgColor} ${textColor}`}>
-    {title}
-  </h4>
-  {
-    sponsors.length > 0 ? (
-      <div class="flex flex-wrap gap-4 mt-4">
+{
+  sponsors.length > 0 ? (
+    <div class="w-full">
+      <div class="flex items-center gap-4 mb-6">
+        <div class:list={['h-px flex-1 opacity-30', tierColor]} style="background: currentColor;" />
+        <h4 class:list={['text-sm font-semibold uppercase tracking-widest', tierColor]}>{title}</h4>
+        <div class:list={['h-px flex-1 opacity-30', tierColor]} style="background: currentColor;" />
+      </div>
+      <div class="flex flex-wrap items-center justify-center gap-6">
         {sponsors.map((sponsor) => (
           <a
             href={sponsor.website}
             target="_blank"
             rel="noopener noreferrer"
-            class="flex flex-col items-center justify-center p-4 border rounded-lg hover:shadow-lg transition-shadow duration-300"
+            class="group relative flex items-center justify-center rounded-xl bg-white/[0.03] border border-white/[0.06] backdrop-blur-sm p-5 transition-all duration-300 hover:bg-white/[0.08] hover:border-white/[0.15] hover:scale-[1.03] hover:shadow-lg hover:shadow-black/20"
           >
             <img
               src={sponsor.logo}
               alt={t['sponsors.altlogo'].replace('{name}', sponsor.name)}
               width={size}
-              style={{ background: sponsor.logobg }}
+              height={Math.round(size * 0.6)}
+              class="object-contain transition-all duration-300 opacity-90 group-hover:opacity-100"
+              style={{
+                background: sponsor.logobg,
+                borderRadius: '0.5rem',
+                padding: '0.5rem',
+                maxHeight: `${Math.round(size * 0.7)}px`,
+              }}
             />
-            <small>{sponsor.name}</small>
           </a>
         ))}
       </div>
-    ) : (
-      <p class="text-gray-100 mt-2 bg-white/10 px-2 py-1 rounded w-[184px] border border-gray-300 text-center">
-        {t['sponsors.none']}
-      </p>
-    )
-  }
-</div>
+    </div>
+  ) : null
+}


### PR DESCRIPTION
## Summary
- Redesign the sponsors section on the home page with a more elegant, modern look
- Replace solid-color tier headers with centered divider labels using tier accent colors
- Use glassmorphism-style cards (`backdrop-blur`, subtle borders, translucent backgrounds) with smooth hover effects (scale, opacity, shadow)
- Hide empty tiers instead of showing "no sponsors" placeholder
- Increase main sponsor logo size (280px) for stronger visual hierarchy across tiers

## Files changed
- `src/components/home/sponsors/SponsorsGroup.astro` — new card design and tier label
- `src/components/home/SectionSponsors.astro` — updated props and spacing
- `src/components/Button.astro` — Prettier formatting only