### PR TITLE
chore: rename build workflow to check and add pre-commit checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,8 +5,8 @@ on:
     branches: [main, develop]
 
 jobs:
-  astro-check:
-    name: Astro check
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,45 +26,8 @@ jobs:
       - name: Astro check
         run: pnpm astro check
 
-  prettier-check:
-    name: Prettier check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install dependencies
-        run: pnpm install
-
       - name: Prettier check
         run: pnpm exec prettier --check src
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    needs: [astro-check, prettier-check]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install dependencies
-        run: pnpm install
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
## Summary

- Renombra el workflow de CI de `build.yml` a `check.yml` y el job de `build` a `check`
- Agrega los mismos checks que corren en el pre-commit: `pnpm astro check` y `pnpm exec prettier --check src`
- El build sigue corriendo al final, solo si los checks previos pasan

fixes #142 