### PR TITLE
chore: inject PUBLIC_GA_ID secret into build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Build with Astro
         run: pnpm run build
+        env:
+          PUBLIC_GA_ID: ${{ secrets.PUBLIC_GA_ID }}
 
       - name: Upload artifact
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

- Inyecta el secret `PUBLIC_GA_ID` como variable de entorno en el step de build del workflow de deploy
- Esto permite que Astro tenga acceso a la variable durante la compilación y la incluya en el bundle

Closes #139