### PR TITLE
Change Perk website URL

### DIFF
--- a/src/data/sponsors/perk.md
+++ b/src/data/sponsors/perk.md
@@ -1,6 +1,6 @@
 ---
 name: 'Perk'
-website: 'https://www.travelperk.com/'
+website: 'https://www.perk.com/'
 tier: 'main'
 logobg: '#ffffff'
 logo: '/sponsors/perk.svg'


### PR DESCRIPTION
Updated the website URL for Perk. It is perk.com, not travelperk.com