### PR TITLE
docs: add development and deployment guide to README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [main]
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+# Automatic release when package.json version changes
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths: [package.json]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: justincy/github-action-npm-release@2.0.2

--- a/README.md
+++ b/README.md
@@ -76,3 +76,22 @@ import Layout from '../../layouts/Layout.astro'
 ### 5. Sitemap
 
 - The sitemap is automatically generated on every build. No manual action is required.
+
+## Development & Deployment
+
+### Branching Strategy
+
+The main branch is `main`. All development work should be done in feature branches created from `main`. All changes must go through a pull request and require approval from the team before merging.
+
+### Deployment Process
+
+When it's time to deploy a new version, follow these steps:
+
+1. Create a new branch from `main` using the format: `chore/<VERSION>`. For example: `chore/v1.0.0`
+2. Update the version in `package.json`
+3. Create a commit with the message: `chore: version 1.0.0`
+4. Create a pull request. Once merged to `main`, pull the latest code.
+5. Create a new tag: `git tag v1.0.0`
+6. Push the tag: `git push origin v1.0.0`
+7. Go to GitHub, navigate to the Releases section, and create a new release. Select the tag and click "Generate release notes", then publish.
+8. Finally, go to GitHub Actions, select "Deploy to GitHub Pages", choose the tag you want to deploy, and run the workflow.

--- a/README.md
+++ b/README.md
@@ -77,21 +77,23 @@ import Layout from '../../layouts/Layout.astro'
 
 - The sitemap is automatically generated on every build. No manual action is required.
 
-## Development & Deployment
+## Releases & Deploys
 
-### Branching Strategy
+### Creating a Release
 
-The main branch is `main`. All development work should be done in feature branches created from `main`. All changes must go through a pull request and require approval from the team before merging.
+The release workflow automatically detects version changes in `package.json`. When you push to `main` with an updated version, it automatically:
 
-### Deployment Process
+1. Creates a git tag
+2. Generates a changelog from commit history
+3. Creates a GitHub Release
 
-When it's time to deploy a new version, follow these steps:
+### Deploying
 
-1. Create a new branch from `main` using the format: `chore/<VERSION>`. For example: `chore/v1.0.0`
-2. Update the version in `package.json`
-3. Create a commit with the message: `chore: version 1.0.0`
-4. Create a pull request. Once merged to `main`, pull the latest code.
-5. Create a new tag: `git tag v1.0.0`
-6. Push the tag: `git push origin v1.0.0`
-7. Go to GitHub, navigate to the Releases section, and create a new release. Select the tag and click "Generate release notes", then publish.
-8. Finally, go to GitHub Actions, select "Deploy to GitHub Pages", choose the tag you want to deploy, and run the workflow.
+Deployment is manual and triggered from GitHub Actions:
+
+1. Go to **Actions → Deploy to GitHub Pages**
+2. Select the tag you want to deploy (e.g., `v1.0.0`)
+3. Click **Run workflow**
+
+The site is deployed to GitHub Pages at `https://2026.es.pycon.org/`.
+


### PR DESCRIPTION
## Summary
- Añade sección "Development & Deployment" al README.md explicando branching strategy y deployment process
- Actualiza workflow de deploy para ejecutarse manualmente en lugar de automáticamente en main

Closes #165