### PR TITLE
fix: center CTA cards grid after CFP removal

### DIFF
--- a/src/components/home/SectionCTAs.astro
+++ b/src/components/home/SectionCTAs.astro
@@ -38,7 +38,7 @@ const ctas = [
 <section aria-labelledby="ctas-heading" class="flex flex-col gap-8">
   <h2 id="ctas-heading" class="sr-only">Llamadas a la participación</h2>
 
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+  <div class="grid grid-cols-1 md:grid-cols-2 max-w-5xl mx-auto gap-6">
     {
       ctas.map((cta) => (
         <article


### PR DESCRIPTION
Changed grid from 3 columns to 2 and added max-w-5xl mx-auto to center the remaining CTA cards.