### PR TITLE
feat: add ticket dates banner to homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2026.es.pycon.org",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/home/SectionDates.astro
+++ b/src/components/home/SectionDates.astro
@@ -1,0 +1,78 @@
+---
+import { texts } from '@/i18n/home'
+
+interface Props {
+  lang: string
+}
+
+const { lang } = Astro.props
+const t = texts[lang as keyof typeof texts]
+
+const dates = [
+  {
+    emoji: '🎫',
+    label: t['tickets.earlybird.label'],
+    date: t['tickets.earlybird.date'],
+    accentBg: 'bg-pycon-orange/10',
+    accentBorder: 'border-pycon-orange/25',
+    accentText: 'text-pycon-orange',
+    bar: 'bg-pycon-orange',
+  },
+  {
+    emoji: '🎟️',
+    label: t['tickets.general.label'],
+    date: t['tickets.general.date'],
+    accentBg: 'bg-amber-400/10',
+    accentBorder: 'border-amber-400/25',
+    accentText: 'text-amber-400',
+    bar: 'bg-amber-400',
+  },
+]
+---
+
+<section aria-labelledby="tickets-heading">
+  <div class="relative rounded-2xl border border-white/10 overflow-hidden">
+    {/* Gradient accent bar at top — visual separator */}
+    <div
+      class="h-1.5 w-full bg-gradient-to-r from-pycon-orange via-amber-400 to-pycon-yellow"
+      aria-hidden="true"
+    >
+    </div>
+
+    {/* Background gradient — different from glassmorphism CTAs */}
+    <div
+      class="bg-gradient-to-b from-pycon-orange/5 via-amber-400/[0.04] to-transparent px-6 py-10 md:px-10 md:py-12"
+    >
+      <div class="flex flex-col items-center gap-2 text-center">
+        <span class="text-3xl" aria-hidden="true">🎟️</span>
+        <h2 id="tickets-heading" class="text-xl md:text-2xl font-bold text-pycon-white">
+          {t['tickets.title']}
+        </h2>
+      </div>
+
+      <div class="mt-8 grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl mx-auto">
+        {
+          dates.map((d) => (
+            <div
+              class:list={[
+                'flex flex-col items-center gap-2 rounded-xl border p-5 text-center',
+                d.accentBg,
+                d.accentBorder,
+              ]}
+            >
+              <span class="text-3xl" aria-hidden="true">
+                {d.emoji}
+              </span>
+              <span class="text-xs uppercase tracking-widest font-semibold text-pycon-gray-25">
+                {d.label}
+              </span>
+              <span class={['text-2xl md:text-3xl font-bold leading-tight', d.accentText].join(' ')}>
+                {d.date}
+              </span>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/index.astro
+++ b/src/components/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import SectionMain from './home/SectionMain.astro'
+import SectionDates from './home/SectionDates.astro'
 import SectionCTAs from './home/SectionCTAs.astro'
 import SectionSponsors from './home/SectionSponsors.astro'
 
@@ -14,6 +15,7 @@ const { lang } = Astro.props
 <Layout title="PyConES 2026">
   <div class="flex flex-col gap-20">
     <SectionMain lang={lang} />
+    <SectionDates lang={lang} />
     <SectionCTAs lang={lang} />
     <SectionSponsors lang={lang} />
   </div>

--- a/src/i18n/home.ts
+++ b/src/i18n/home.ts
@@ -27,6 +27,11 @@ export const texts = {
     'cta.reviewers.description':
       'Buscamos personas que nos ayuden a revisar las propuestas que recibamos. Tu experiencia y criterio son clave para garantizar la calidad del programa. Si querés colaborar con la organización y ayudar a seleccionar las mejores charlas y talleres, ¡necesitamos tu ayuda!',
     'cta.reviewers.button': 'Quiero ser revisor/a',
+    'tickets.title': '🎟️ Entradas',
+    'tickets.earlybird.label': 'Early Bird',
+    'tickets.earlybird.date': '5 de junio',
+    'tickets.general.label': 'Venta General',
+    'tickets.general.date': '19 de junio',
   },
   en: {
     'index.initializing': 'Initialising system...',
@@ -57,6 +62,11 @@ export const texts = {
     'cta.reviewers.description':
       'We are looking for people to help us review the proposals we receive. Your experience and judgement are key to ensuring the quality of the programme. If you want to collaborate with the organisation and help select the best talks and workshops, we need your help!',
     'cta.reviewers.button': 'I want to be a reviewer',
+    'tickets.title': '🎟️ Tickets',
+    'tickets.earlybird.label': 'Early Bird',
+    'tickets.earlybird.date': 'June 5',
+    'tickets.general.label': 'General Sale',
+    'tickets.general.date': 'June 19',
   },
   ca: {
     'index.initializing': 'Inicialitzant sistema...',
@@ -87,5 +97,10 @@ export const texts = {
     'cta.reviewers.description':
       "Busquem persones que ens ajudin a revisar les propostes que rebem. La teva experiència i criteri són clau per garantir la qualitat del programa. Si vols col·laborar amb l'organització i ajudar a seleccionar les millors xerrades i tallers, necessitem la teva ajuda!",
     'cta.reviewers.button': 'Vull ser revisor/a',
+    'tickets.title': '🎟️ Entrades',
+    'tickets.earlybird.label': 'Early Bird',
+    'tickets.earlybird.date': '5 de juny',
+    'tickets.general.label': 'Venda General',
+    'tickets.general.date': '19 de juny',
   },
 } as const


### PR DESCRIPTION
### Cambios

Se agregó un banner de anuncio en la home con las fechas de venta de entradas:

- 🎫 **Early Bird**: 5 de junio
- 🎟️ **Venta General**: 19 de junio

### Detalles técnicos

- Nuevo componente `src/components/home/SectionDates.astro` — banner con barra degradada y fondo tintado, visualmente distinto a las CTAs
- Textos i18n en español, inglés y catalán
- Integrado en `src/components/index.astro` entre `SectionMain` y `SectionCTAs`

### Preview
<img width="1562" height="444" alt="Captura de pantalla 2026-05-23 a las 16 34 01" src="https://github.com/user-attachments/assets/98bf7f8d-9bc2-4ee9-9f98-97d0afa2a93c" />

![preview](https://github.com/user-attachments/assets/soon...)