### PR TITLE
feat: add Early Bird tickets banner and remove obsolete CTAs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ dist/
 *.local
 
 .claude
+.agents/
+skills-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2026.es.pycon.org",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/home/SectionEarlyBird.astro
+++ b/src/components/home/SectionEarlyBird.astro
@@ -1,0 +1,83 @@
+---
+import { texts } from '../../i18n/home'
+import { menuTexts } from '../../i18n/menu'
+import Button from '../Button.astro'
+
+interface Props {
+  lang: string
+}
+
+const { lang } = Astro.props
+const t = texts[lang as keyof typeof texts]
+const menuT = menuTexts[lang as keyof typeof menuTexts]
+---
+
+<div class="relative py-16 px-4 overflow-hidden">
+  <div
+    class="absolute inset-0 bg-gradient-to-b from-pycon-red-50/20 via-pycon-red-50/10 to-transparent"
+    aria-hidden="true"
+  >
+  </div>
+
+  <div class="relative max-w-3xl mx-auto flex flex-col items-center gap-8 animate-slide-down">
+    <div class="flex items-center gap-4">
+      <span class="text-5xl animate-bounce" aria-hidden="true">🎫</span>
+      <h2
+        class="text-3xl md:text-4xl font-black text-center text-pycon-yellow drop-shadow-[0_0_12px_rgba(255,199,44,0.5)]"
+      >
+        {t['earlybird.title']}
+      </h2>
+      <span class="text-5xl animate-bounce" aria-hidden="true">🎫</span>
+    </div>
+
+    <div
+      class="w-full bg-gradient-to-br from-pycon-red-50/15 via-pycon-black/80 to-pycon-red-50/10 backdrop-blur-md p-10 rounded-2xl border-2 border-pycon-red-50/50 shadow-[0_0_30px_rgba(249,66,58,0.3)] hover:shadow-[0_0_40px_rgba(249,66,58,0.5)] hover:border-pycon-red-50 transition-all duration-500"
+    >
+      <p class="text-xl md:text-2xl text-white leading-relaxed mb-10 text-center font-medium">
+        {t['earlybird.description']}
+      </p>
+
+      <div class="flex justify-center">
+        <a
+          href="https://pretix.eu/python-spain/pycones-2026/"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${t['earlybird.button']} ${menuT.new_tab}`}
+          class="group relative inline-flex items-center justify-center gap-3 px-10 py-5 text-xl font-bold rounded-xl text-white bg-pycon-red-50 border-2 border-pycon-red-50 hover:bg-pycon-red-100 hover:border-pycon-red-100 shadow-[0_0_20px_rgba(249,66,58,0.4)] hover:shadow-[0_0_35px_rgba(249,66,58,0.6)] transition-all duration-300"
+        >
+          {t['earlybird.button']}
+          <svg
+            class="w-6 h-6 shrink-0 group-hover:translate-x-1 transition-transform duration-300"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2.5"
+              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  @keyframes slide-down {
+    from {
+      opacity: 0;
+      transform: translateY(-30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .animate-slide-down {
+    animation: slide-down 0.6s ease-out forwards;
+  }
+</style>

--- a/src/components/index.astro
+++ b/src/components/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import SectionMain from './home/SectionMain.astro'
-import SectionCTAs from './home/SectionCTAs.astro'
+import SectionEarlyBird from './home/SectionEarlyBird.astro'
 import SectionSponsors from './home/SectionSponsors.astro'
 
 interface Props {
@@ -14,7 +14,7 @@ const { lang } = Astro.props
 <Layout title="PyConES 2026">
   <div class="flex flex-col gap-20">
     <SectionMain lang={lang} />
-    <SectionCTAs lang={lang} />
+    <SectionEarlyBird lang={lang} />
     <SectionSponsors lang={lang} />
   </div>
 </Layout>

--- a/src/i18n/home.ts
+++ b/src/i18n/home.ts
@@ -19,14 +19,10 @@ export const texts = {
       '¡Ya está abierta la llamada a propuestas! Mándanos tu charla o taller antes del 17 de mayo a las 23:59h (hora peninsular). Si te estás preguntando si puedes hacer esto, la respuesta es que sí. Si tienes un tema que te interesa, ¡nos interesa!',
     'cfp.help': 'Si necesitas ayuda con tu propuesta, no dudes en escribirnos a charlas@2026.es.pycon.org',
     'cfp.button': 'Envía tu propuesta',
-    'cta.sponsors.title': '¡Buscamos Patrocinadores!',
-    'cta.sponsors.description':
-      'Ser patrocinador de la PyConES es una oportunidad para apoyar a la comunidad Python, conectar con talento técnico de alto nivel y ganar visibilidad en un entorno ligado al software libre y la innovación. Si formás parte o conocés a alguien de una empresa interesada en apoyar la comunidad Python, ¡ayudanos a llegar a ella!',
-    'cta.sponsors.button': 'Más información sobre patrocinios',
-    'cta.reviewers.title': 'Llamada a Revisores/as',
-    'cta.reviewers.description':
-      'Buscamos personas que nos ayuden a revisar las propuestas que recibamos. Tu experiencia y criterio son clave para garantizar la calidad del programa. Si querés colaborar con la organización y ayudar a seleccionar las mejores charlas y talleres, ¡necesitamos tu ayuda!',
-    'cta.reviewers.button': 'Quiero ser revisor/a',
+    'earlybird.title': '¡Entradas Early Bird disponibles!',
+    'earlybird.description':
+      'La venta de entradas con descuento Early Bird ya ha comenzado. ¡No te pierdas esta oportunidad única de aprender, conectar y crecer en la comunidad Python!',
+    'earlybird.button': 'Comprar entradas',
   },
   en: {
     'index.initializing': 'Initialising system...',
@@ -49,14 +45,10 @@ export const texts = {
     'cfp.help':
       "If you need help with your proposal, don't hesitate to contact us at charlas@2026.es.pycon.org.",
     'cfp.button': 'Submit your proposal',
-    'cta.sponsors.title': 'We Are Looking for Sponsors!',
-    'cta.sponsors.description':
-      'Sponsoring PyConES is an opportunity to support the Python community, connect with high-level technical talent, and gain visibility in an environment linked to free software and innovation. If you are or know someone at a company interested in supporting the Python community, help us reach them!',
-    'cta.sponsors.button': 'More info about sponsorships',
-    'cta.reviewers.title': 'Call for Reviewers',
-    'cta.reviewers.description':
-      'We are looking for people to help us review the proposals we receive. Your experience and judgement are key to ensuring the quality of the programme. If you want to collaborate with the organisation and help select the best talks and workshops, we need your help!',
-    'cta.reviewers.button': 'I want to be a reviewer',
+    'earlybird.title': 'Early Bird tickets are now available!',
+    'earlybird.description':
+      'Early Bird discounted tickets are now on sale. Do not miss this unique opportunity to learn, connect, and grow in the Python community!',
+    'earlybird.button': 'Buy tickets',
   },
   ca: {
     'index.initializing': 'Inicialitzant sistema...',
@@ -79,13 +71,9 @@ export const texts = {
     'cfp.help':
       'Si necessites ajuda amb la teva proposta, no dubtis en escriure a charlas@2026.es.pycon.org.',
     'cfp.button': 'Envia la teva proposta',
-    'cta.sponsors.title': 'Busquem Patrocinadors!',
-    'cta.sponsors.description':
-      "Ser patrocinador de la PyConES és una oportunitat per donar suport a la comunitat Python, connectar amb talent tècnic d'alt nivell i guanyar visibilitat en un entorn lligat al programari lliure i la innovació. Si formes part o coneixes algú d'una empresa interessada en donar suport a la comunitat Python, ajuda'ns a arribar-hi!",
-    'cta.sponsors.button': 'Més informació sobre patrocinis',
-    'cta.reviewers.title': 'Crida a Revisors/es',
-    'cta.reviewers.description':
-      "Busquem persones que ens ajudin a revisar les propostes que rebem. La teva experiència i criteri són clau per garantir la qualitat del programa. Si vols col·laborar amb l'organització i ajudar a seleccionar les millors xerrades i tallers, necessitem la teva ajuda!",
-    'cta.reviewers.button': 'Vull ser revisor/a',
+    'earlybird.title': 'Entrades Early Bird disponibles!',
+    'earlybird.description':
+      "La venda d'entrades amb descompte Early Bird ja ha començat. No et perdis aquesta oportunitat única d'aprendre, connectar i créixer en la comunitat Python!",
+    'earlybird.button': 'Comprar entrades',
   },
 } as const


### PR DESCRIPTION
- Add SectionEarlyBird component with prominent red banner
- Link to pretix.eu/python-spain/pycones-2026/ for ticket sales
- Remove cta.sponsors and cta.reviewers (redundant with menu)
<img width="416" height="944" alt="Screenshot from 2026-06-05 13-18-17" src="https://github.com/user-attachments/assets/a1a0be82-40b2-432e-9d8b-068e223f4d95" />

<img width="1343" height="469" alt="Screenshot from 2026-06-05 13-28-34" src="https://github.com/user-attachments/assets/53f2b3c1-846b-43ef-bf63-e42abbe9da35" />
