### PR TITLE
Eliminar Inditex de lista de patros anteriores.

### DIFF
--- a/src/i18n/sponsors/ca.ts
+++ b/src/i18n/sponsors/ca.ts
@@ -171,7 +171,6 @@ export const ca = {
       { name: 'Raiola Networks', editions: 1, logo: '/sponsors/raiola.png' },
       { name: 'Perk', editions: 1, logo: '/sponsors/perk.svg' },
       { name: 'Brite', editions: 1, logo: '/sponsors/logo-brite.svg' },
-      { name: 'Inditex Tech', editions: 1, logo: '/sponsors/logo-inditex-tech.avif' },
       { name: 'Fever', editions: 1, logo: '/sponsors/fever.png' },
       { name: 'Kiwi.com', editions: 1, logo: '/sponsors/kiwi.png' },
       { name: 'NIQ', editions: 1, logo: '/sponsors/NIQ.png' },

--- a/src/i18n/sponsors/en.ts
+++ b/src/i18n/sponsors/en.ts
@@ -175,7 +175,6 @@ export const en = {
       { name: 'Raiola Networks', editions: 1, logo: '/sponsors/raiola.png' },
       { name: 'Perk', editions: 1, logo: '/sponsors/perk.svg' },
       { name: 'Brite', editions: 1, logo: '/sponsors/logo-brite.svg' },
-      { name: 'Inditex Tech', editions: 1, logo: '/sponsors/logo-inditex-tech.avif' },
       { name: 'Fever', editions: 1, logo: '/sponsors/fever.png' },
       { name: 'Kiwi.com', editions: 1, logo: '/sponsors/kiwi.png' },
       { name: 'NIQ', editions: 1, logo: '/sponsors/NIQ.png' },

--- a/src/i18n/sponsors/es.ts
+++ b/src/i18n/sponsors/es.ts
@@ -191,7 +191,6 @@ export const es = {
       { name: 'Raiola Networks', editions: 1, logo: '/sponsors/raiola.png' },
       { name: 'Perk', editions: 1, logo: '/sponsors/perk.svg' },
       { name: 'Brite', editions: 1, logo: '/sponsors/logo-brite.svg' },
-      { name: 'Inditex Tech', editions: 1, logo: '/sponsors/logo-inditex-tech.avif' },
       { name: 'Fever', editions: 1, logo: '/sponsors/fever.png' },
       { name: 'Kiwi.com', editions: 1, logo: '/sponsors/kiwi.png' },
       { name: 'NIQ', editions: 1, logo: '/sponsors/NIQ.png' },


### PR DESCRIPTION
En principio no tenemos permiso para utilizar su marca de esta manera, y se quejaron en el pasado.