### PR TITLE
Difuminar los bordes de la sección de entradas early bird con gradiente radial

### DIFF
--- a/src/components/home/SectionEarlyBird.astro
+++ b/src/components/home/SectionEarlyBird.astro
@@ -14,7 +14,7 @@ const menuT = menuTexts[lang as keyof typeof menuTexts]
 
 <div class="relative py-16 px-4 overflow-hidden">
   <div
-    class="absolute inset-0 bg-gradient-to-b from-pycon-red-50/20 via-pycon-red-50/10 to-transparent"
+    class="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(252,160,156,0.22)_0%,rgba(252,160,156,0.12)_45%,transparent_75%)]"
     aria-hidden="true"
   >
   </div>


### PR DESCRIPTION
Cierra #197

## Problema
La sección de entradas early bird tenía un gradiente lineal vertical en el fondo. Solo se difuminaba arriba y abajo — los costados izquierdo y derecho mantenían la opacidad completa y, al recortarlos el `overflow-hidden` del contenedor padre, quedaban bordes visibles y duros.

## Cambio
Se reemplazó el gradiente lineal del div de fondo en `SectionEarlyBird.astro` por un gradiente radial centrado:

```astro
class="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(252,160,156,0.22)_0%,rgba(252,160,156,0.12)_45%,transparent_75%)]"
```

La forma radial hace que el color se desvanezca de forma pareja hacia los cuatro costados. Se mantiene el mismo color `--color-pycon-red-50` (`#fca09c`); solo se ajustaron los valores de alfa (0.22 en el centro, 0.12 al 45%, transparente al 75%) para conservar una intensidad visual similar a la original.

## Verificación
- Recargar `/` en `pnpm dev`
- El halo rojizo ahora se difumina de forma uniforme hacia los cuatro bordes de la sección
- El `backdrop-blur-md` del card interno y el resto del markup quedan intactos
- Sin regresión de accesibilidad: se mantiene `aria-hidden="true"` en el div decorativo

## Capturas

Antes:

<img width="1520" height="1144" alt="SCR-20260613-jjur" src="https://github.com/user-attachments/assets/779d393c-21ca-4ffb-8a7d-0ae53590b7b3" />

Después:

<img width="1902" height="1034" alt="SCR-20260613-jkzj" src="https://github.com/user-attachments/assets/a3715912-5686-4a52-a2a5-a7bd831fe1b0" />

Closes #197 