### PR TITLE
Programa: añadir página con widget de Pretalx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2026.es.pycon.org",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",
-    "@commitlint/cli": "21.2.0",
+    "@commitlint/cli": "21.2.1",
     "@commitlint/config-conventional": "21.2.0",
     "husky": "9.1.7",
     "lint-staged": "17.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 0.9.9
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.9.4)(typescript@6.0.3)
       '@commitlint/cli':
-        specifier: 21.2.0
-        version: 21.2.0(@types/node@24.12.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
+        specifier: 21.2.1
+        version: 21.2.1(@types/node@24.12.0)(conventional-commits-parser@7.0.1)(typescript@6.0.3)
       '@commitlint/config-conventional':
         specifier: 21.2.0
         version: 21.2.0
@@ -243,8 +243,8 @@ packages:
     resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
     engines: {node: '>= 20.12.0'}
 
-  '@commitlint/cli@21.2.0':
-    resolution: {integrity: sha512-4GLVIhUaT3c3GBlQ0GB80/5H3xXdn/Tgw4lrsuoOQVDu2wl4Xw0GuzSar8xZKSMv4H3xaKaQXmvH91GmdyYBZA==}
+  '@commitlint/cli@21.2.1':
+    resolution: {integrity: sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -288,8 +288,8 @@ packages:
     resolution: {integrity: sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/read@21.2.0':
-    resolution: {integrity: sha512-ELx8Ovh/JoAw5lpvDgxc6Y0We9skf2IPI2RFN+gnYgDGjRdMSF8zeodxhZmcclLWzfUIF7hXLOa8gOlllYcvBA==}
+  '@commitlint/read@21.2.1':
+    resolution: {integrity: sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/resolve-extends@21.2.0':
@@ -312,12 +312,12 @@ packages:
     resolution: {integrity: sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==}
     engines: {node: '>=22.12.0'}
 
-  '@conventional-changelog/git-client@2.6.0':
-    resolution: {integrity: sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==}
-    engines: {node: '>=18'}
+  '@conventional-changelog/git-client@3.1.0':
+    resolution: {integrity: sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==}
+    engines: {node: '>=22'}
     peerDependencies:
-      conventional-commits-filter: ^5.0.0
-      conventional-commits-parser: ^6.3.0
+      conventional-commits-filter: ^6.0.1
+      conventional-commits-parser: ^7.0.1
     peerDependenciesMeta:
       conventional-commits-filter:
         optional: true
@@ -947,13 +947,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@simple-libs/child-process-utils@1.0.2':
-    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
-    engines: {node: '>=18'}
-
-  '@simple-libs/stream-utils@1.2.0':
-    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
-    engines: {node: '>=18'}
+  '@simple-libs/child-process-utils@2.0.0':
+    resolution: {integrity: sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==}
+    engines: {node: '>=22'}
 
   '@simple-libs/stream-utils@2.0.0':
     resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
@@ -1257,11 +1253,6 @@ packages:
     resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
     engines: {node: '>=22'}
 
-  conventional-commits-parser@6.4.0:
-    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   conventional-commits-parser@7.0.1:
     resolution: {integrity: sha512-6VtskFpPsNkGVk/TY2RnV/MEdKfvCPBtQZN9x8jh9+k5RWBQ+tiaWn5UFCzTr0Dd88iKx7xghxbjBRp5uIzp3g==}
     engines: {node: '>=22'}
@@ -1457,12 +1448,6 @@ packages:
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
-
-  git-raw-commits@5.0.1:
-    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
-    engines: {node: '>=18'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
-    hasBin: true
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -1673,10 +1658,6 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
-
-  meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
-    engines: {node: '>=18'}
 
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
@@ -2538,13 +2519,13 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@commitlint/cli@21.2.0(@types/node@24.12.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
+  '@commitlint/cli@21.2.1(@types/node@24.12.0)(conventional-commits-parser@7.0.1)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-conventional': 21.2.0
       '@commitlint/format': 21.2.0
       '@commitlint/lint': 21.2.0
       '@commitlint/load': 21.2.0(@types/node@24.12.0)(typescript@6.0.3)
-      '@commitlint/read': 21.2.0(conventional-commits-parser@6.4.0)
+      '@commitlint/read': 21.2.1(conventional-commits-parser@7.0.1)
       '@commitlint/types': 21.2.0
       tinyexec: 1.2.4
       yargs: 18.0.0
@@ -2611,11 +2592,11 @@ snapshots:
       conventional-changelog-angular: 9.2.1
       conventional-commits-parser: 7.0.1
 
-  '@commitlint/read@21.2.0(conventional-commits-parser@6.4.0)':
+  '@commitlint/read@21.2.1(conventional-commits-parser@7.0.1)':
     dependencies:
       '@commitlint/top-level': 21.2.0
       '@commitlint/types': 21.2.0
-      git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
+      '@conventional-changelog/git-client': 3.1.0(conventional-commits-parser@7.0.1)
       tinyexec: 1.2.4
     transitivePeerDependencies:
       - conventional-commits-filter
@@ -2647,13 +2628,13 @@ snapshots:
       conventional-commits-parser: 7.0.1
       picocolors: 1.1.1
 
-  '@conventional-changelog/git-client@2.6.0(conventional-commits-parser@6.4.0)':
+  '@conventional-changelog/git-client@3.1.0(conventional-commits-parser@7.0.1)':
     dependencies:
-      '@simple-libs/child-process-utils': 1.0.2
-      '@simple-libs/stream-utils': 1.2.0
+      '@simple-libs/child-process-utils': 2.0.0
+      '@simple-libs/stream-utils': 2.0.0
       semver: 7.8.5
     optionalDependencies:
-      conventional-commits-parser: 6.4.0
+      conventional-commits-parser: 7.0.1
 
   '@conventional-changelog/template@1.2.1': {}
 
@@ -3083,11 +3064,9 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@simple-libs/child-process-utils@1.0.2':
+  '@simple-libs/child-process-utils@2.0.0':
     dependencies:
-      '@simple-libs/stream-utils': 1.2.0
-
-  '@simple-libs/stream-utils@1.2.0': {}
+      '@simple-libs/stream-utils': 2.0.0
 
   '@simple-libs/stream-utils@2.0.0': {}
 
@@ -3445,12 +3424,6 @@ snapshots:
     dependencies:
       '@conventional-changelog/template': 1.2.1
 
-  conventional-commits-parser@6.4.0:
-    dependencies:
-      '@simple-libs/stream-utils': 1.2.0
-      meow: 13.2.0
-    optional: true
-
   conventional-commits-parser@7.0.1:
     dependencies:
       '@simple-libs/stream-utils': 2.0.0
@@ -3643,14 +3616,6 @@ snapshots:
   get-tsconfig@5.0.0-beta.4:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
-    dependencies:
-      '@conventional-changelog/git-client': 2.6.0(conventional-commits-parser@6.4.0)
-      meow: 13.2.0
-    transitivePeerDependencies:
-      - conventional-commits-filter
-      - conventional-commits-parser
 
   github-slugger@2.0.0: {}
 
@@ -3850,8 +3815,6 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.12.2: {}
-
-  meow@13.2.0: {}
 
   meow@14.1.0: {}
 

--- a/src/components/ProgramaPage.astro
+++ b/src/components/ProgramaPage.astro
@@ -1,0 +1,41 @@
+---
+import { programaTexts } from '@/i18n/programa'
+import { menuTexts } from '@/i18n/menu'
+
+interface Props {
+  lang: string
+}
+const { lang } = Astro.props
+const t = programaTexts[lang as keyof typeof programaTexts]
+const menuT = menuTexts[lang as keyof typeof menuTexts]
+---
+
+<section class="py-8">
+  <h1 class="text-3xl md:text-5xl font-bold text-center mb-6">{t.title}</h1>
+  <p class="text-center text-base md:text-lg mb-10 max-w-2xl mx-auto opacity-80">{t.intro}</p>
+
+  <div class="bg-white overflow-x-auto p-4">
+    <pretalx-schedule
+      event-url="https://pretalx.com/pycones-2025/"
+      locale={t.locale}
+      format="grid"
+      style="--pretalx-clr-primary: #03004b"></pretalx-schedule>
+  </div>
+
+  <noscript>
+    <div class="pretalx-widget">
+      <div class="pretalx-widget-info-message">
+        {t.noscript}{' '}
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${t.noscriptLink} ${menuT.new_tab}`}
+          href="https://pretalx.com/pycones-2025/schedule/"
+        >
+          {t.noscriptLink}
+        </a>
+        .
+      </div>
+    </div>
+  </noscript>
+</section>

--- a/src/components/ProgramaPage.astro
+++ b/src/components/ProgramaPage.astro
@@ -14,13 +14,11 @@ const menuT = menuTexts[lang as keyof typeof menuTexts]
   <h1 class="text-3xl md:text-5xl font-bold text-center mb-6">{t.title}</h1>
   <p class="text-center text-base md:text-lg mb-10 max-w-2xl mx-auto opacity-80">{t.intro}</p>
 
-  <div class="bg-white overflow-x-auto p-4">
-    <pretalx-schedule
-      event-url="https://pretalx.com/pycones-2025/"
-      locale={t.locale}
-      format="grid"
-      style="--pretalx-clr-primary: #03004b"></pretalx-schedule>
-  </div>
+  <pretalx-schedule
+    event-url="https://pretalx.com/pycones-2026/"
+    locale={t.locale}
+    format="grid"
+    style="--pretalx-clr-primary: #03004b"></pretalx-schedule>
 
   <noscript>
     <div class="pretalx-widget">
@@ -30,7 +28,7 @@ const menuT = menuTexts[lang as keyof typeof menuTexts]
           target="_blank"
           rel="noopener noreferrer"
           aria-label={`${t.noscriptLink} ${menuT.new_tab}`}
-          href="https://pretalx.com/pycones-2025/schedule/"
+          href="https://pretalx.com/pycones-2026/schedule/"
         >
           {t.noscriptLink}
         </a>

--- a/src/i18n/menu/ca.ts
+++ b/src/i18n/menu/ca.ts
@@ -5,6 +5,10 @@ export const ca = {
       href: '/',
     },
     {
+      label: 'Programa',
+      href: '/programa',
+    },
+    {
       label: 'Informació',
       children: [
         {

--- a/src/i18n/menu/en.ts
+++ b/src/i18n/menu/en.ts
@@ -5,6 +5,10 @@ export const en = {
       href: '/',
     },
     {
+      label: 'Programme',
+      href: '/programa',
+    },
+    {
       label: 'Information',
       children: [
         {

--- a/src/i18n/menu/es.ts
+++ b/src/i18n/menu/es.ts
@@ -5,6 +5,10 @@ export const es = {
       href: '/',
     },
     {
+      label: 'Programa',
+      href: '/programa',
+    },
+    {
       label: 'Información',
       children: [
         {

--- a/src/i18n/programa/ca.ts
+++ b/src/i18n/programa/ca.ts
@@ -1,0 +1,8 @@
+export const ca = {
+  title: 'Programa',
+  seoDescription: 'Consulta el cronograma complet de xerrades, tallers i activitats de la PyConES 2026.',
+  intro: 'Explora totes les xerrades, tallers i activitats de la PyConES 2026.',
+  locale: 'ca',
+  noscript: 'JavaScript està desactivat al teu navegador. Per veure el programa sense JavaScript,',
+  noscriptLink: 'fes clic aquí',
+} as const

--- a/src/i18n/programa/en.ts
+++ b/src/i18n/programa/en.ts
@@ -1,0 +1,8 @@
+export const en = {
+  title: 'Programme',
+  seoDescription: 'Check out the full schedule of talks, workshops and activities at PyConES 2026.',
+  intro: 'Explore all the talks, workshops and activities at PyConES 2026.',
+  locale: 'en',
+  noscript: 'JavaScript is disabled in your browser. To view the schedule without JavaScript,',
+  noscriptLink: 'click here',
+} as const

--- a/src/i18n/programa/es.ts
+++ b/src/i18n/programa/es.ts
@@ -1,0 +1,8 @@
+export const es = {
+  title: 'Programa',
+  seoDescription: 'Consulta el cronograma completo de charlas, talleres y actividades de la PyConES 2026.',
+  intro: 'Explora todas las charlas, talleres y actividades de la PyConES 2026.',
+  locale: 'es',
+  noscript: 'JavaScript está deshabilitado en tu navegador. Para ver el programa sin JavaScript,',
+  noscriptLink: 'haz click aquí',
+} as const

--- a/src/i18n/programa/index.ts
+++ b/src/i18n/programa/index.ts
@@ -1,0 +1,5 @@
+import { es } from './es'
+import { en } from './en'
+import { ca } from './ca'
+
+export const programaTexts = { es, en, ca }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,9 +9,10 @@ import { ClientRouter } from 'astro:transitions'
 interface Props {
   title: string
   description?: string // Optional (?)
+  fullWidth?: boolean
 }
 const { lang = 'es' } = Astro.params
-const { title, description = 'PyconES 2026' } = Astro.props
+const { title, description = 'PyconES 2026', fullWidth = false } = Astro.props
 
 const siteUrl = Astro.site ? Astro.site.origin : 'https://2026.es.pycon.org'
 const canonicalURL = new URL(Astro.url.pathname, siteUrl)
@@ -121,7 +122,12 @@ const alternates = [
     </div>
     <Header lang={lang as string} />
 
-    <main class="relative grow z-10 flex flex-col justify-center container mx-auto p-4 md:p-8">
+    <main
+      class:list={[
+        'relative grow z-10 flex flex-col justify-center',
+        fullWidth ? 'px-4 md:px-8' : 'container mx-auto p-4 md:p-8',
+      ]}
+    >
       <slot />
     </main>
     <Footer lang={lang as string} />

--- a/src/pages/[lang]/programa.astro
+++ b/src/pages/[lang]/programa.astro
@@ -1,0 +1,42 @@
+---
+import Layout from '../../layouts/Layout.astro'
+import ProgramaPage from '../../components/ProgramaPage.astro'
+import { programaTexts } from '../../i18n/programa'
+
+export function getStaticPaths() {
+  return [{ params: { lang: 'es' } }, { params: { lang: 'en' } }, { params: { lang: 'ca' } }]
+}
+
+const { lang } = Astro.params
+const t = programaTexts[(lang || 'es') as keyof typeof programaTexts]
+---
+
+<Layout title={t.title} description={t.seoDescription} fullWidth>
+  <div class="grow w-full md:mt-24 mt-12">
+    <ProgramaPage lang={lang || 'es'} />
+  </div>
+  <script is:inline src="https://pretalx.com/pycones-2025/widgets/schedule.js"></script>
+  <script is:inline>
+    function injectPretalxDialogStyles() {
+      const schedule = document.querySelector('pretalx-schedule')
+      if (!schedule?.shadowRoot) return
+      if (schedule.shadowRoot.querySelector('#pycones-dialog-fix')) return
+      const style = document.createElement('style')
+      style.id = 'pycones-dialog-fix'
+      style.textContent = `
+        #filter-bottom-sheet-dialog,
+        #filter-bottom-sheet-dialog .dialog-inner {
+          background: #fff !important;
+          color: #0d0f10 !important;
+        }
+      `
+      schedule.shadowRoot.appendChild(style)
+    }
+    customElements.whenDefined('pretalx-schedule').then(injectPretalxDialogStyles)
+    new MutationObserver(injectPretalxDialogStyles).observe(document.body, {
+      childList: true,
+      subtree: true,
+    })
+    document.addEventListener('astro:page-load', injectPretalxDialogStyles)
+  </script>
+</Layout>

--- a/src/pages/[lang]/programa.astro
+++ b/src/pages/[lang]/programa.astro
@@ -15,7 +15,7 @@ const t = programaTexts[(lang || 'es') as keyof typeof programaTexts]
   <div class="grow w-full md:mt-24 mt-12">
     <ProgramaPage lang={lang || 'es'} />
   </div>
-  <script is:inline src="https://pretalx.com/pycones-2025/widgets/schedule.js"></script>
+  <script is:inline src="https://pretalx.com/pycones-2026/widgets/schedule.js"></script>
   <script is:inline>
     function injectPretalxDialogStyles() {
       const schedule = document.querySelector('pretalx-schedule')


### PR DESCRIPTION
## Descripción

Añade la página `/programa` con el widget de Pretalx embebido, mostrando el cronograma de PyConES en los 3 idiomas soportados (es/en/ca).

## Cambios

- **Nueva página** `src/pages/[lang]/programa.astro` con `getStaticPaths` para es/en/ca
- **Nuevo componente** `src/components/ProgramaPage.astro` (h1, intro, widget, noscript fallback)
- **Nuevo módulo i18n** `src/i18n/programa/{index,es,en,ca}.ts`
- **Menú**: `Programa` / `Programme` insertado como 2º item (después de "Inicio")
- **Layout**: nueva prop opcional `fullWidth` para contenido full-viewport (sin container)
- **Widget**: wrapeado en `overflow-x-auto` para scroll horizontal en viewports angostos
- **Dialog de filtros**: estilos inyectados al shadow root del widget vía JS (Pretalx usa Shadow DOM, el CSS del light DOM no penetra)

## Testing

- [ ] Abrir `/es/programa` y verificar que el calendario carga y se ve bien
- [ ] Repetir en `/en/programa` y `/ca/programa`
- [ ] Pulsar el botón de filtros y comprobar que el dialog sale con fondo blanco
- [ ] Probar scroll horizontal del calendario en mobile
- [ ] Verificar que el menú muestra "Programa" como 2º item en los 3 idiomas

## Notas

- El widget apunta a `event-url="https://pretalx.com/pycones-2025/"` por ahora (es el evento con schedule publicado). Cambiar a `pycones-2026` cuando exista el evento con cronograma.
- El locale `ca` puede caer al default (inglés) si Pretalx no tiene UI en catalán para este evento. Si se quiere forzar castellano, cambiar `locale: 'ca'` por `locale: 'es'` solo en `src/i18n/programa/ca.ts`.