### PR TITLE
Fix: fondo negro en modales del widget de pretalx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2026.es.pycon.org",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -19,10 +19,10 @@
     "@astrojs/sitemap": "3.7.3",
     "@fontsource-variable/jetbrains-mono": "5.2.8",
     "@fontsource-variable/outfit": "5.2.8",
-    "@lucide/astro": "1.23.0",
+    "@lucide/astro": "1.24.0",
     "@tailwindcss/vite": "4.3.2",
     "animejs": "4.5.0",
-    "astro": "7.0.6",
+    "astro": "7.0.7",
     "tailwindcss": "4.3.2"
   },
   "devDependencies": {
@@ -31,7 +31,7 @@
     "@commitlint/config-conventional": "21.2.0",
     "husky": "9.1.7",
     "lint-staged": "17.0.8",
-    "prettier": "3.9.4",
+    "prettier": "3.9.5",
     "prettier-plugin-astro": "0.14.1",
     "typescript": "6.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.2.8
         version: 5.2.8
       '@lucide/astro':
-        specifier: 1.23.0
-        version: 1.23.0(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0))
+        specifier: 1.24.0
+        version: 1.24.0(astro@7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: 4.3.2
         version: 4.3.2(vite@8.1.0(@types/node@24.12.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -27,15 +27,15 @@ importers:
         specifier: 4.5.0
         version: 4.5.0
       astro:
-        specifier: 7.0.6
-        version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0)
+        specifier: 7.0.7
+        version: 7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0)
       tailwindcss:
         specifier: 4.3.2
         version: 4.3.2
     devDependencies:
       '@astrojs/check':
         specifier: 0.9.9
-        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.9.4)(typescript@6.0.3)
+        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.9.5)(typescript@6.0.3)
       '@commitlint/cli':
         specifier: 21.2.1
         version: 21.2.1(@types/node@24.12.0)(conventional-commits-parser@7.0.1)(typescript@6.0.3)
@@ -49,8 +49,8 @@ importers:
         specifier: 17.0.8
         version: 17.0.8
       prettier:
-        specifier: 3.9.4
-        version: 3.9.4
+        specifier: 3.9.5
+        version: 3.9.5
       prettier-plugin-astro:
         specifier: 0.14.1
         version: 0.14.1
@@ -158,8 +158,8 @@ packages:
   '@astrojs/sitemap@3.7.3':
     resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
 
-  '@astrojs/telemetry@3.3.2':
-    resolution: {integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==}
+  '@astrojs/telemetry@3.3.3':
+    resolution: {integrity: sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@astrojs/yaml2ts@0.2.4':
@@ -673,8 +673,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lucide/astro@1.23.0':
-    resolution: {integrity: sha512-SP5JHwI46QJjCJGzS8BTQsUXcHJoGkVIeywN12NraSiTEt4uh0iNLPs4hEHTSJr+LbZeHxc3W1BiRJPF2tS5Yw==}
+  '@lucide/astro@1.24.0':
+    resolution: {integrity: sha512-UmQrHv3/SfulzmALy6M0H4TOAaql/OG68V7yoFDW4g4F49vQ8o32NQHK4xBm+8k8zD/JQNHt00z2YRKXJ6bnCA==}
     peerDependencies:
       astro: ^4 || ^5 || ^6 || ^7
 
@@ -1162,8 +1162,8 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
-  astro@7.0.6:
-    resolution: {integrity: sha512-Myw0sFia+zs/Y0yqfZEsUYXfDPh3ELcLf1f0Q/qQzVXBh/af1qO62WNT+P89DCcfGVV51nMoQhEfkBYqJmoUOQ==}
+  astro@7.0.7:
+    resolution: {integrity: sha512-swqrKDSI/B83GFroYPZYMFcxqbSe9+tkynu1WDBk3GLgBfV9++qVM4Z+2uFT6uu9A53Q0TROnxLketfMEENuqQ==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
     peerDependencies:
@@ -1496,11 +1496,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-docker@3.0.0:
-    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
-
   is-docker@4.0.0:
     resolution: {integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==}
     engines: {node: '>=20'}
@@ -1514,18 +1509,9 @@ packages:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
 
-  is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
-    engines: {node: '>=14.16'}
-    hasBin: true
-
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  is-wsl@3.1.1:
-    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
-    engines: {node: '>=16'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1782,8 +1768,8 @@ packages:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
     engines: {node: ^14.15.0 || >=16.0.0}
 
-  prettier@3.9.4:
-    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
+  prettier@3.9.5:
+    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2253,10 +2239,6 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
-  which-pm-runs@1.1.0:
-    resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
-    engines: {node: '>=4'}
-
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
     engines: {node: '>=20'}
@@ -2318,9 +2300,9 @@ packages:
 
 snapshots:
 
-  '@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.9.4)(typescript@6.0.3)':
+  '@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.9.5)(typescript@6.0.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.9.4)(typescript@6.0.3)
+      '@astrojs/language-server': 2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.9.5)(typescript@6.0.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 6.0.3
@@ -2398,7 +2380,7 @@ snapshots:
       smol-toml: 1.6.0
       unified: 11.0.5
 
-  '@astrojs/language-server@2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.9.4)(typescript@6.0.3)':
+  '@astrojs/language-server@2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.9.5)(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.4
@@ -2412,14 +2394,14 @@ snapshots:
       volar-service-css: 0.0.70(@volar/language-service@2.4.28)
       volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
       volar-service-html: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.9.4)
+      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.9.5)
       volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
       volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
       volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
       vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
-      prettier: 3.9.4
+      prettier: 3.9.5
       prettier-plugin-astro: 0.14.1
     transitivePeerDependencies:
       - typescript
@@ -2441,13 +2423,12 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/telemetry@3.3.2':
+  '@astrojs/telemetry@3.3.3':
     dependencies:
       ci-info: 4.4.0
       dset: 3.1.4
       is-docker: 4.0.0
-      is-wsl: 3.1.1
-      which-pm-runs: 1.1.0
+      package-manager-detector: 1.6.0
 
   '@astrojs/yaml2ts@0.2.4':
     dependencies:
@@ -2875,9 +2856,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lucide/astro@1.23.0(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0))':
+  '@lucide/astro@1.24.0(astro@7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0))':
     dependencies:
-      astro: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0)
+      astro: 7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0)
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -3265,12 +3246,12 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0):
+  astro@7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.55.1)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/markdown-satteri': 0.3.3
-      '@astrojs/telemetry': 3.3.2
+      '@astrojs/telemetry': 3.3.3
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.6.0
       '@oslojs/encoding': 1.1.0
@@ -3674,8 +3655,6 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-docker@3.0.0: {}
-
   is-docker@4.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -3684,15 +3663,7 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
 
-  is-inside-container@1.0.0:
-    dependencies:
-      is-docker: 3.0.0
-
   is-plain-obj@4.1.0: {}
-
-  is-wsl@3.1.1:
-    dependencies:
-      is-inside-container: 1.0.0
 
   jiti@2.7.0: {}
 
@@ -3924,10 +3895,10 @@ snapshots:
   prettier-plugin-astro@0.14.1:
     dependencies:
       '@astrojs/compiler': 2.13.0
-      prettier: 3.9.4
+      prettier: 3.9.5
       sass-formatter: 0.7.9
 
-  prettier@3.9.4: {}
+  prettier@3.9.5: {}
 
   prismjs@1.30.0: {}
 
@@ -4321,12 +4292,12 @@ snapshots:
     optionalDependencies:
       '@volar/language-service': 2.4.28
 
-  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.9.4):
+  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.9.5):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.28
-      prettier: 3.9.4
+      prettier: 3.9.5
 
   volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -4393,8 +4364,6 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  which-pm-runs@1.1.0: {}
-
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -4422,7 +4391,7 @@ snapshots:
       '@vscode/l10n': 0.0.18
       ajv: 8.17.1
       ajv-draft-04: 1.0.0(ajv@8.17.1)
-      prettier: 3.9.4
+      prettier: 3.9.5
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8
       vscode-languageserver: 9.0.1

--- a/src/components/ProgramaPage.astro
+++ b/src/components/ProgramaPage.astro
@@ -18,7 +18,7 @@ const menuT = menuTexts[lang as keyof typeof menuTexts]
     event-url="https://pretalx.com/pycones-2026/"
     locale={t.locale}
     format="grid"
-    style="--pretalx-clr-primary: #03004b"></pretalx-schedule>
+    style="--pretalx-clr-primary: #03004b; color-scheme: light"></pretalx-schedule>
 
   <noscript>
     <div class="pretalx-widget">

--- a/src/pages/[lang]/programa.astro
+++ b/src/pages/[lang]/programa.astro
@@ -16,27 +16,4 @@ const t = programaTexts[(lang || 'es') as keyof typeof programaTexts]
     <ProgramaPage lang={lang || 'es'} />
   </div>
   <script is:inline src="https://pretalx.com/pycones-2026/widgets/schedule.js"></script>
-  <script is:inline>
-    function injectPretalxDialogStyles() {
-      const schedule = document.querySelector('pretalx-schedule')
-      if (!schedule?.shadowRoot) return
-      if (schedule.shadowRoot.querySelector('#pycones-dialog-fix')) return
-      const style = document.createElement('style')
-      style.id = 'pycones-dialog-fix'
-      style.textContent = `
-        #filter-bottom-sheet-dialog,
-        #filter-bottom-sheet-dialog .dialog-inner {
-          background: #fff !important;
-          color: #0d0f10 !important;
-        }
-      `
-      schedule.shadowRoot.appendChild(style)
-    }
-    customElements.whenDefined('pretalx-schedule').then(injectPretalxDialogStyles)
-    new MutationObserver(injectPretalxDialogStyles).observe(document.body, {
-      childList: true,
-      subtree: true,
-    })
-    document.addEventListener('astro:page-load', injectPretalxDialogStyles)
-  </script>
 </Layout>


### PR DESCRIPTION
## Resumen

Reemplaza el hack de inyección de estilos en el shadow DOM del widget de `pretalx-schedule` por una única declaración CSS (`color-scheme: light`) en el host. Resuelve el fondo negro que aparecía en los modales internos (filter bottom sheet y diálogo de detalle de sesión) cuando el navegador está en dark mode.

## Problema

Al cargar la página `/programa`, los modales internos del widget de Pretalx se veían con fondo negro y texto casi ilegible — incluso con el hack previo, el modal de detalle de sesión ("Taller Django Girls", etc.) seguía mostrándose en negro.

## Causa raíz

- `pretalx-schedule` renderiza sus modales (`SessionModal`, `FilterBottomSheet`) con un `<dialog>` nativo **sin `background-color` declarado**.
- Sin color explícito, el navegador le aplica el system color `Canvas`, que es **negro en dark mode**.
- El hack anterior (`<script is:inline>` con `MutationObserver` que inyectaba un `<style>` dentro del shadow root) solo atacaba `#filter-bottom-sheet-dialog` con un selector hardcoded — frágil y silenciosamente incompleto para el modal de detalle.
- Además, `pretalx-schedule` no expone `::part()`, ni slots, ni variables CSS para el fondo de modales. La única palanca real de theming "externa" es el set de custom properties `--pretalx-clr-*` que ya se venían usando para el color de marca.

## Solución

`color-scheme` es una propiedad CSS **heredable** que cruza la frontera del shadow DOM sin necesidad de JavaScript. Aplicada al host `<pretalx-schedule>`, fuerza al navegador a usar los UA defaults del esquema light (Canvas blanco, CanvasText negro, `::backdrop` semi-transparente estándar) en todo el subárbol, incluidos los `<dialog>` internos.

```diff
- style="--pretalx-clr-primary: #03004b"
+ style="--pretalx-clr-primary: #03004b; color-scheme: light"
```

Y se elimina el bloque `<script is:inline>` completo de `src/pages/[lang]/programa.astro` (la función `injectPretalxDialogStyles`, el `MutationObserver` observando `document.body` con `subtree: true`, el listener de `customElements.whenDefined` y el de `astro:page-load`).

## Por qué es mejor que el hack anterior

- **Menos código**: 1 atributo CSS vs 23 líneas de JS.
- **Sin tocar shadow DOM**: respetamos el encapsulamiento que el componente promete.
- **Inmune a cambios upstream**: los IDs internos de Pretalx pueden cambiar entre versiones sin afectarnos.
- **Cero overhead en runtime**: nos deshacemos del `MutationObserver` con `subtree: true` que observaba todo el `document.body` (anti-patrón de performance, se disparaba en cada mutación del DOM).

## Verificación

Probado en browser con dark mode activo:

- ✅ Modal de detalle de sesión ("Taller Django Girls"): fondo blanco, texto negro, links legibles
- ✅ Filter bottom sheet: sigue funcionando con su overlay oscuro
- ✅ Tabla principal del schedule: sin cambios visuales
- ✅ `pnpm astro check` y `prettier --check` pasan sin errores

## Trabajo futuro (opcional)

Abrir issue en [pretalx/pretalx](https://github.com/pretalx/pretalx) pidiendo que `SessionModal.vue` y `FilterBottomSheet.vue` expongan `--pretalx-clr-modal-bg`, `--pretalx-clr-modal-text` y `--pretalx-clr-backdrop` en `:host` para que los consumidores podamos tematizar los modales sin depender de UA color-scheme. Sería un cambio de ~5 líneas en el source del componente.
