### PR TITLE
fix(programa): responsive issues in view-mode toggle and grid view

### DIFF
--- a/src/components/ProgramaPage.astro
+++ b/src/components/ProgramaPage.astro
@@ -24,12 +24,6 @@ const schedule = await getSchedule()
     class="schedule-view-toggle max-w-3xl mx-auto mb-8 border border-white/10 rounded-xl p-3 flex flex-wrap items-center gap-2 bg-pycon-black/40"
   >
     <legend class="sr-only">{t.list.viewModeLegend}</legend>
-    <span
-      aria-hidden="true"
-      class="text-xs uppercase tracking-wider text-pycon-gray-25/70 px-2 font-semibold"
-    >
-      {t.list.viewModeLegend}
-    </span>
     <label
       class="cursor-pointer px-4 py-2 rounded-lg text-sm has-[:checked]:bg-pycon-orange has-[:checked]:text-pycon-black has-[:checked]:font-semibold text-pycon-gray-25 transition-colors"
     >
@@ -107,12 +101,14 @@ const schedule = await getSchedule()
   </div>
 
   <div id="schedule-grid-view" class="schedule-view" data-view="grid">
-    <pretalx-schedule
-      event-url="https://pretalx.com/pycones-2026/"
-      locale={t.locale}
-      format="grid"
-      style="--pretalx-clr-primary: #03004b; --pretalx-clr-success: #2e7d32; color-scheme: light"
-    ></pretalx-schedule>
+    <div class="overflow-x-auto max-w-full">
+      <pretalx-schedule
+        event-url="https://pretalx.com/pycones-2026/"
+        locale={t.locale}
+        format="grid"
+        style="--pretalx-clr-primary: #03004b; --pretalx-clr-success: #2e7d32; color-scheme: light"
+      ></pretalx-schedule>
+    </div>
 
     <div id="schedule-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
 


### PR DESCRIPTION
## Summary

Two small responsive fixes for `/programa`.

### 1. Remove redundant view-mode label
The `<span>` displaying "Schedule view mode" was redundant with the radio labels ("List" / "Visual grid") and forced the fieldset to wrap to two rows on mobile (375px), making the toggle 86px tall. The accessible `<legend>` remains for screen readers.

### 2. Wrap `<pretalx-schedule>` in overflow container
The Pretalx web component renders an internal layout of ~1690px that caused horizontal page scroll in tablet (768) and desktop (1280). The shadow DOM can't be styled from outside, so a `max-w-full overflow-x-auto` wrapper provides internal scroll instead of forcing page-level scroll.

## Verification

Playwright at 375 / 768 / 1280:
- No horizontal overflow on list or grid view
- Toggle height 62px across all breakpoints, single-row layout on mobile

## Files changed

- `src/components/ProgramaPage.astro` (+8 / -12)