### PR TITLE
fix(jobs): show job offers on production again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2026.es.pycon.org",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/JobsPage.astro
+++ b/src/components/JobsPage.astro
@@ -12,7 +12,7 @@ const t = jobsTexts[(lang || 'es') as keyof typeof jobsTexts]
 const menuT = menuTexts[(lang || 'es') as keyof typeof menuTexts]
 const locale = (lang || 'es') as TLocale
 
-const jobModules = Object.values(import.meta.glob('../data/jobs/!(_*).md', { eager: true })) as {
+const jobModules = Object.values(import.meta.glob(['../data/jobs/*.md'], { eager: true })) as {
   frontmatter: IJob
 }[]
 


### PR DESCRIPTION
## Summary
- Replace the jobs `import.meta.glob` extglob (`!(_*)`) with a plain `*.md` pattern so Vite 8 (Astro 7) can resolve job markdown files in production builds.
- Draft offers (Fever, JetBrains, `_plantilla-oferta`) stay hidden via the existing `draft !== true` filter.

## Why local ≠ production
Jobs used `import.meta.glob('../data/jobs/!(_*).md')`. That extglob worked on older Vite, but Astro 7 / Vite 8 uses `tinyglobby` and does not support extglobs in production builds. The glob matched **zero** files on CI → empty jobs page online, while Rover still appeared locally. Sponsors/speakers were fine because they already use plain `*.md` globs.

Note using `pnpm dev` with Astro 7 / Vite 8 still showed the offers, while `pnpm build && pnpm preview` does not.